### PR TITLE
Fix handling of the state parameter on Clever-initiated requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Unofficial OmniAuth strategy for [Clever SSO OAuth2](https://dev.clever.com/sso)
 
 Add the gem to your application's Gemfile:
 
-    gem 'omniauth-clever', '~> 1.2.0'
+    gem 'omniauth-clever', '~> 1.2.1'
 
 And then execute:
 
@@ -27,6 +27,11 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :clever, ENV['CLEVER_CLIENT_ID'], ENV['CLEVER_CLIENT_SECRET']
 end
 ```
+
+Clever is a unique OAuth 2.0 service provider in that login sequences
+are often initiated by Clever, not the client. When Clever initiates
+login, a state parameter is not relevant nor sent.
+
 
 ## Configuring
 

--- a/lib/omniauth/clever/version.rb
+++ b/lib/omniauth/clever/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Clever
-    VERSION = "1.2.0"
+    VERSION = "1.2.1"
   end
 end

--- a/lib/omniauth/strategies/clever.rb
+++ b/lib/omniauth/strategies/clever.rb
@@ -4,13 +4,21 @@ require 'base64'
 module OmniAuth
   module Strategies
     class Clever < OmniAuth::Strategies::OAuth2
-      option :name, "clever"
+      # Clever is a unique OAuth 2.0 service provider in that login sequences
+      # are often initiated by Clever, not the client. When Clever initiates
+      # login, a state parameter is not relevant nor sent.
 
+      option :name, "clever"
       option :client_options, {
         :site          => 'https://api.clever.com',
         :authorize_url => 'https://clever.com/oauth/authorize',
         :token_url     => 'https://clever.com/oauth/tokens'
       }
+
+      # This option bubbles up to the OmniAuth::Strategies::OAuth2
+      # when we call super in the callback_phase below.
+      # **State will still be verified** when login is initiated by the client.
+      option :provider_ignores_state, true
 
       def token_params
         super.tap do |params|
@@ -18,7 +26,21 @@ module OmniAuth
         end
       end
 
-
+      def callback_phase
+        error = request.params["error_reason"] || request.params["error"]
+        stored_state = session.delete("omniauth.state")
+        if error
+          fail!(error, CallbackError.new(request.params["error"], request.params["error_description"] || request.params["error_reason"], request.params["error_uri"]))
+        else
+          # Only verify state if we've initiated login and have stored a state
+          # to compare to.
+          if stored_state && (!request.params["state"] || request.params["state"] != stored_state)
+            fail!(:csrf_detected, CallbackError.new(:csrf_detected, "CSRF detected"))
+          else
+            super
+          end
+        end
+      end
 
       uid{ raw_info['data']['id'] }
 


### PR DESCRIPTION
Resolves a bug where omniauth-clever would fail to process inbound redirect_uri requests without a state parameter. Clever's implementation often initiates login without state. This fix changes behavior to only verify state when it has been initiated by the client.