### PR TITLE
Fixed instructions for using district_id in district picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :clever, ENV['CLEVER_CLIENT_ID'], ENV['CLEVER_CLIENT_SECRET'],
            :setup => lambda { |env|
              params = Rack::Utils.parse_query(env['QUERY_STRING'])
-             env['omniauth.strategy'].options[:client_options][:district_id] = params['district_id']
+             env['omniauth.strategy'].options[:authorize_params][:district_id] = params['district_id']
            }
 end
 ```


### PR DESCRIPTION
Setting district_id param with client_options didn't pass through to the clever auth district page, setting with authorize_params does.