### PR TITLE
Relax omniauth-oauth2 version requirement.

### DIFF
--- a/omniauth-clever.gemspec
+++ b/omniauth-clever.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.1.1'
+  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.1'
 end


### PR DESCRIPTION
Relaxing version requirement to allow this library to play nicely with other omniauth-oauth2 libraries.