### PR TITLE
Add option for full_host to allow Clever login from non-secure pages

### DIFF
--- a/lib/omniauth/strategies/clever.rb
+++ b/lib/omniauth/strategies/clever.rb
@@ -20,6 +20,18 @@ module OmniAuth
       # **State will still be verified** when login is initiated by the client.
       option :provider_ignores_state, true
 
+      option :full_host
+
+      # Allows full host to be overridden. This is important because Clever is forcing https in production,
+      # so we need to use https redirect url even when our host page is http.
+      def full_host
+        if options.full_host.blank?
+          super
+        else
+          options.full_host
+        end
+      end
+
       def token_params
         super.tap do |params|
           params[:headers] = {'Authorization' => "Basic #{Base64.strict_encode64("#{options.client_id}:#{options.client_secret}")}"}


### PR DESCRIPTION
This change allows you to specify the full_host for the Clever omniauth.

Example using devise:

```
config.omniauth :clever, Settings.clever.news.client_id, Settings.clever.news.client_secret, { name: 'clever', provider_ignores_state: true, full_host: 'https://myhost.com' } 
```

Note that you can also set the `full_host` for **all** omniauth libraries with the following code:

```
OmniAuth.config.full_host = "https://myhost.com"
```

However, since this affects all other oauth logins, we would prefer not to have to re-test everything.

BTW, this change has been used in production for over a year, but seeing now that there is an official Clever fork, we'd like to contribute this back.
