### PR TITLE
Fix unknown redirect uri

### DIFF
--- a/lib/omniauth/strategies/clever.rb
+++ b/lib/omniauth/strategies/clever.rb
@@ -57,6 +57,11 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get('/me').parsed
       end
+
+      # Fix unknown redirect uri bug by NOT appending the query string to the callback url.
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end


### PR DESCRIPTION
This is a critical bug fix for applications that are using omniauth-oauth2 1.4.0 or later.

The change at https://github.com/intridea/omniauth-oauth2/pull/70, which was released in omniauth-oauth2 version 1.4.0 breaks clever logins due to extra query string parameters being appended to the callback url.