### PR TITLE
Loosen oauth2 version restriction

### DIFF
--- a/omniauth-clever.gemspec
+++ b/omniauth-clever.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.1', '<= 1.5'
+  gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.1'
 end


### PR DESCRIPTION
We need to be able to use omniauth-oauth2 v2.0.