### PR TITLE
Update omniauth-oauth2 to 1.8

### DIFF
--- a/lib/omniauth/clever/version.rb
+++ b/lib/omniauth/clever/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Clever
-    VERSION = "1.2.2"
+    VERSION = "1.2.3"
   end
 end

--- a/omniauth-clever.gemspec
+++ b/omniauth-clever.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.1', '<= 1.5'
+  gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.1', '<= 1.8'
 end


### PR DESCRIPTION
This extends support into Rails 7, which has a dependency on an upgraded omniauth-oauth2 gem.